### PR TITLE
Allow multi-key-commands

### DIFF
--- a/asyncio_redis_cluster/replies.py
+++ b/asyncio_redis_cluster/replies.py
@@ -247,7 +247,7 @@ class EvalScriptReply:
         Coroutine that returns a Python representation of the script's return
         value.
         """
-        from asyncio_redis.protocol import MultiBulkReply
+        from .protocol import MultiBulkReply
 
         @asyncio.coroutine
         def decode(obj):


### PR DESCRIPTION
This little fix allows to use commands that need a list of keys as first argument like brpop. 
There is also fixed a little import error and my editor corrected some PEP8 stuff in the pool file.
